### PR TITLE
Remove debugger and fix onAnimationStart usage

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,12 +22,16 @@ interface Props {
 
 const AutofillInput: React.FC<Props & React.InputHTMLAttributes<HTMLInputElement>> = ({
   onAutoFill,
+  onAnimationStart,
   ...props
 }) => {
   return (
     <input
       css={animation}
       onAnimationStart={e => {
+        // Allow users to still use the onAnimationStart callback
+        onAnimationStart && onAnimationStart(e)
+
         if (e.animationName === onAutoFillStart.name) {
           onAutoFill(true);
         } else if (e.animationName === onAutoFillCancel.name) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,6 @@ const AutofillInput: React.FC<Props & React.InputHTMLAttributes<HTMLInputElement
     <input
       css={animation}
       onAnimationStart={e => {
-        debugger;
         if (e.animationName === onAutoFillStart.name) {
           onAutoFill(true);
         } else if (e.animationName === onAutoFillCancel.name) {


### PR DESCRIPTION
There was a debugger statement in the master branch, and there was a subtle bug where someone using this library that tries to use `onAnimationStart` would find that it didn't work.

This was because `onAnimationStart` was being used internally, and not "proxied" through the component to the parent.

This change just makes it so that if `onAnimationStart` is provided in the `<AutofillInput />` component, that it will be called as well right before `onAutoFill` is called, allowing this component to mostly be a drop-in replacement for `<input />`.

The only other aspect which should be handled is this component should forward refs, and then it would be a true drop-in-replacement, however I don't have time to do that and test it well at this time!